### PR TITLE
Check if API response_body is undefined

### DIFF
--- a/lib/error/error.js
+++ b/lib/error/error.js
@@ -49,11 +49,15 @@ class AftershipError {
 	 */
 	static getApiError(response_body, retry_count) {
 		let error = new Error();
-		error.type = response_body.meta.type;
-		error.message = response_body.meta.message;
-		error.code = response_body.meta.code;
-		error.data = response_body.data;
-		error.response_body = JSON.stringify(response_body);
+		if (typeof response_body == 'undefined') {
+			error.message = 'API response_body is null'
+		} else {
+			error.type = response_body.meta.type;
+			error.message = response_body.meta.message;
+			error.code = response_body.meta.code;
+			error.data = response_body.data;
+			error.response_body = JSON.stringify(response_body);
+		}
 
 		if (retry_count) {
 			error.retry_count = retry_count;


### PR DESCRIPTION
Fixes #17 

When the API is down - as it is now, https://status.aftership.com/, reporting a "Major Outage" in the API - then our sails app throws the error: "Cannot read property 'meta' of undefined" as described in #17 