### PR TITLE
Fix not return promise bug

### DIFF
--- a/lib/aftership.js
+++ b/lib/aftership.js
@@ -49,7 +49,7 @@ class Aftership {
 			this[methods[i]] = function () {
 				let args = Array.prototype.slice.call(arguments);
 				args.unshift(methods[i]);
-				_this.call.apply(_this, args);
+				return _this.call.apply(_this, args);
 			};
 		}
 	}


### PR DESCRIPTION
The wrapper function GET,POST,PUT,DELETE failed to return a Promise if we call them without specifying the callback function, the root cause is that the wrapper function missed the return at the last statement.