### PR TITLE
Update vunerable dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,21 +23,21 @@
     "test": "grunt lint && grunt coverage"
   },
   "dependencies": {
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.11",
     "request": "^2.67.0",
     "uuid": "^3.2.1"
   },
   "devDependencies": {
     "chai": "^3.4.1",
-    "eslint": "^1.10.3",
+    "eslint": "^5.6.0",
     "eslint-config-aftership": "^1.10.1",
-    "grunt": "^0.4.5",
+    "grunt": "^1.0.3",
     "grunt-eslint": "^17.3.1",
     "grunt-mocha-istanbul": "^3.0.1",
     "http-proxy": "^1.12.0",
     "istanbul": "^0.4.2",
     "load-grunt-config": "^0.19.1",
-    "mocha": "^2.3.4",
+    "mocha": "^5.2.0",
     "pre-commit": "^1.1.2",
     "proxyquire": "^2.0.1",
     "sinon": "^1.17.2"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-config-aftership": "^1.10.1",
     "grunt": "^1.0.3",
     "grunt-eslint": "^17.3.1",
-    "grunt-mocha-istanbul": "^3.0.1",
+    "grunt-mocha-istanbul": "^5.0.2",
     "http-proxy": "^1.12.0",
     "istanbul": "^0.4.2",
     "load-grunt-config": "^0.19.1",


### PR DESCRIPTION
This update reduces number of vulnerabilities from 15 down to 2 and both are in dev dependencies.

```
                       === npm audit security report ===

# Run  npm install --save-dev grunt-eslint@21.0.0  to resolve 1 vulnerability
SEMVER WARNING: Recommended action is a potentially breaking change
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ grunt-eslint [dev]                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ grunt-eslint > eslint > inquirer > lodash                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/577                       │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌──────────────────────────────────────────────────────────────────────────────┐
│                                Manual Review                                 │
│            Some vulnerabilities require your attention to resolve            │
│                                                                              │
│         Visit https://go.npm.me/audit-guide for additional guidance          │
└──────────────────────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.17.5                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ load-grunt-config [dev]                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ load-grunt-config > lodash                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/577                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

load-grunt-config can't be updated because it is unmaitained.
grunt-eslint can't be updated, because your ruleset is incompatible with later versions:

```
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing     space-after-keywords
  1:1  error  Rule 'space-return-throw-case' was removed and replaced by: keyword-spacing  space-return-throw-case
  1:1  error  Rule 'no-empty-label' was removed and replaced by: no-labels                 no-empty-label

 3:1  error  Parsing error: The keyword 'const' is reserved
```

Fixes #27