### PR TITLE
Rename Checkpoint and support client side

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 ![codecov.io](http://codecov.io/github/AfterShip/aftership-sdk-nodejs/branch.svg?branch=master)
 
 node.js SDK for AfterShip API
+> It could be used on both client and server side.
+
 ## Installation
 ```
 npm install aftership
@@ -315,7 +317,7 @@ aftership.tracking
   .catch((e) => console.log(e));
 ```
 
-> You can always use/:tracking_id to replace /:slug/:tracking_number.
+> You can always use /:tracking_id to replace /:slug/:tracking_number.
 ```javascript
 // GET /trackings/:tracking_id
 aftership.tracking

--- a/README.md
+++ b/README.md
@@ -117,7 +117,10 @@ console.log(aftership.rate_limit);
 After making an API call, it will be set.
 ```javascript
 aftership.courier.listCouriers()
-  .then(result => console.log(result))
+  .then(result => {
+    console.log(result);
+    console.log(aftership.rate_limit);
+  })
   .catch(err => console.log(err));
 
 // console output
@@ -340,7 +343,7 @@ aftership.tracking
 **GET** /last_checkpoint/:slug/:tracking_number
 
 ```javascript
-aftership.last_checkpoint.getLastCheckPoint({
+aftership.last_checkpoint.getLastCheckpoint({
     slug: 'ups',
     tracking_number: '1234567890',
   })

--- a/example/last_checkpoint.js
+++ b/example/last_checkpoint.js
@@ -6,7 +6,7 @@ const { AfterShip } = require('../dist/index.js');
 const aftership = new AfterShip(API_KEY);
 
 // GET /last_checkpoint/:slug/:tracking_number
-aftership.last_checkpoint.getLastCheckPoint({
+aftership.last_checkpoint.getLastCheckpoint({
     slug: 'ups',
     tracking_number: '1234567890',
   })
@@ -14,7 +14,7 @@ aftership.last_checkpoint.getLastCheckPoint({
   .catch(e => console.log(e));
 
 // GET /last_checkpoint/:tracking_id
-aftership.last_checkpoint.getLastCheckPoint({
+aftership.last_checkpoint.getLastCheckpoint({
     tracking_id: '5b74f4958776db0e00b6f5ed',
   })
   .then(result => console.log(result))

--- a/src/endpoint/last_checkpoint_endpoint.ts
+++ b/src/endpoint/last_checkpoint_endpoint.ts
@@ -1,11 +1,11 @@
 import { AftershipResponse } from '../model/aftership_response';
-import { LastCheckPoint } from '../model/last_checkpoint/last_checkpoint';
+import { LastCheckpoint } from '../model/last_checkpoint/last_checkpoint';
 import { SingleTrackingParam } from '../model/tracking/single_tracking_param';
 
 /**
  * Get tracking information of the last checkpoint of a tracking.
  */
-export interface LastCheckPointEndpoint {
+export interface LastCheckpointEndpoint {
   /**
    * Return the tracking information of the last checkpoint of a single tracking.
    * @param tracking_param The param to identify the single tracking.
@@ -16,9 +16,9 @@ export interface LastCheckPointEndpoint {
    * Default: none, Example: city,tag
    * @param lang Optional, Support Chinese to English translation for china-ems and china-post only. (Example: en)
    */
-  getLastCheckPoint(
+  getLastCheckpoint(
     tracking_param: SingleTrackingParam,
     fields?: string,
     lang?: string,
-  ): Promise<AftershipResponse<LastCheckPoint>>;
+  ): Promise<AftershipResponse<LastCheckpoint>>;
 }

--- a/src/implementation/last_checkpoint.ts
+++ b/src/implementation/last_checkpoint.ts
@@ -1,11 +1,11 @@
 import { ApiRequest } from '../lib/api_request';
 import { AftershipResponse } from '../model/aftership_response';
-import { LastCheckPointEndpoint } from '../endpoint/last_checkpoint_endpoint';
+import { LastCheckpointEndpoint } from '../endpoint/last_checkpoint_endpoint';
 import { SingleTrackingParam } from '../model/tracking/single_tracking_param';
-import { LastCheckPoint } from '../model/last_checkpoint/last_checkpoint';
+import { LastCheckpoint } from '../model/last_checkpoint/last_checkpoint';
 import { buildTrackingUrl, isStringValid } from '../lib/util';
 
-export class LastCheckPointImplementation implements LastCheckPointEndpoint {
+export class LastCheckpointImplementation implements LastCheckpointEndpoint {
   private readonly request: ApiRequest;
 
   constructor(request: ApiRequest) {
@@ -22,11 +22,11 @@ export class LastCheckPointImplementation implements LastCheckPointEndpoint {
    * Default: none, Example: city,tag
    * @param lang Optional, Support Chinese to English translation for china-ems and china-post only. (Example: en)
    */
-  public getLastCheckPoint(
+  public getLastCheckpoint(
     tracking_param: SingleTrackingParam,
     fields?: string,
     lang?: string,
-  ): Promise<AftershipResponse<LastCheckPoint>> {
+  ): Promise<AftershipResponse<LastCheckpoint>> {
     try {
       let trackingUrl = buildTrackingUrl(tracking_param);
       // Add optional params to tracking url
@@ -44,7 +44,7 @@ export class LastCheckPointImplementation implements LastCheckPointEndpoint {
       }
 
       // make request
-      return this.request.makeRequest<null, LastCheckPoint>({
+      return this.request.makeRequest<null, LastCheckpoint>({
         method: 'GET',
         url: `/last_checkpoint/${trackingUrl}`,
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ import { LastCheckpointImplementation } from './implementation/last_checkpoint';
 import { NotificationImplementation } from './implementation/notification';
 import { TrackingImplementation } from './implementation/tracking';
 
-const DEFAULT_API_KEY = process.env['AFTERSHIP_API_KEY'];
 const DEFAULT_ENDPOINT = 'https://api.aftership.com/v4';
 const DEFAULT_USER_AGENT = 'aftership-sdk-nodejs';
 
@@ -47,8 +46,8 @@ export class AfterShip {
   public readonly tracking: TrackingImplementation;
 
   constructor(apiKey: string, options?: AftershipOption) {
-    this.apiKey = this.getApiKey(apiKey);
-    this.errorHandling(this.apiKey, options);
+    this.errorHandling(apiKey, options);
+    this.apiKey = apiKey;
 
     // Setup
     if (options !== null && options !== undefined) {
@@ -76,18 +75,6 @@ export class AfterShip {
     this.last_checkpoint = new LastCheckpointImplementation(request);
     this.notification = new NotificationImplementation(request);
     this.tracking = new TrackingImplementation(request);
-  }
-
-  private getApiKey(apiKey: string): string {
-    if (apiKey !== undefined && apiKey !== '') {
-      return apiKey;
-    }
-
-    if (DEFAULT_API_KEY !== undefined) {
-      return DEFAULT_API_KEY;
-    }
-
-    return '';
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,10 @@ import { AftershipOption } from './model/aftership_option';
 import { RateLimit } from './model/rate_limit';
 import { isStringValid } from './lib/util';
 import { CourierEndpoint } from './endpoint/courier_endpoint';
-import { LastCheckPointEndpoint } from './endpoint/last_checkpoint_endpoint';
+import { LastCheckpointEndpoint } from './endpoint/last_checkpoint_endpoint';
 import { NotificationEndpoint } from './endpoint/notification_endpoint';
 import { CourierImplementation } from './implementation/courier';
-import { LastCheckPointImplementation } from './implementation/last_checkpoint';
+import { LastCheckpointImplementation } from './implementation/last_checkpoint';
 import { NotificationImplementation } from './implementation/notification';
 import { TrackingImplementation } from './implementation/tracking';
 
@@ -32,9 +32,9 @@ export class AfterShip {
   public readonly courier: CourierEndpoint;
 
   /**
-   * Last CheckPoint endpoint
+   * Last Checkpoint endpoint
    */
-  public readonly last_checkpoint: LastCheckPointEndpoint;
+  public readonly last_checkpoint: LastCheckpointEndpoint;
 
   /**
    * Notification endpoint
@@ -73,7 +73,7 @@ export class AfterShip {
 
     // Endpoints
     this.courier = new CourierImplementation(request);
-    this.last_checkpoint = new LastCheckPointImplementation(request);
+    this.last_checkpoint = new LastCheckpointImplementation(request);
     this.notification = new NotificationImplementation(request);
     this.tracking = new TrackingImplementation(request);
   }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -2,6 +2,8 @@ import { AftershipError } from '../error/error';
 import { ErrorEnum } from '../error/error_enum';
 import { SingleTrackingParam } from '../model/tracking/single_tracking_param';
 
+const VERSION = '6.0.0-alpha';
+
 /**
  * Build tracking url by param
  * @param param tracking param
@@ -50,9 +52,14 @@ export function isStringValid(val: string | undefined): boolean {
  * Get the version of Node.js SDK
  */
 export function getSdkVersion(): string {
-  let version = process.env.npm_package_version;
+  let version;
+
+  if (process !== undefined && process.env !== undefined) {
+    version = process.env.npm_package_version;
+  }
+
   if (version === undefined) {
-    version = '6.0.0-alpha';
+    version = VERSION;
   }
 
   return version;

--- a/src/model/checkpoint/checkpoint.ts
+++ b/src/model/checkpoint/checkpoint.ts
@@ -3,7 +3,7 @@ import { DeliveryStatus } from '../tracking/delivery_status';
 /**
  * checkpoint information.
  */
-export interface CheckPoint {
+export interface Checkpoint {
 
   /**
    * Date and time of the tracking created.
@@ -52,7 +52,7 @@ export interface CheckPoint {
   country_name?: string;
 
   /**
-   * CheckPoint message
+   * Checkpoint message
    */
   message?: string;
 
@@ -77,7 +77,7 @@ export interface CheckPoint {
   zip?: string;
 
   /**
-   * CheckPoint status provided by courier (if any)
+   * Checkpoint status provided by courier (if any)
    */
   raw_tag?: string;
 }

--- a/src/model/last_checkpoint/last_checkpoint.ts
+++ b/src/model/last_checkpoint/last_checkpoint.ts
@@ -1,10 +1,10 @@
-import { CheckPoint } from '../checkpoint/checkpoint';
+import { Checkpoint } from '../checkpoint/checkpoint';
 import { DeliveryStatus } from '../tracking/delivery_status';
 
 /**
- * Last CheckPoint Object
+ * Last Checkpoint Object
  */
-export interface LastCheckPoint {
+export interface LastCheckpoint {
   /**
    * Tracking number.
    */
@@ -36,5 +36,5 @@ export interface LastCheckPoint {
   /**
    * Hash describes the checkpoint information.
    */
-  checkpoint: CheckPoint;
+  checkpoint: Checkpoint;
 }

--- a/src/model/tracking/tracking.ts
+++ b/src/model/tracking/tracking.ts
@@ -1,4 +1,4 @@
-import { CheckPoint } from '../checkpoint/checkpoint';
+import { Checkpoint } from '../checkpoint/checkpoint';
 import { DeliveryStatus } from './delivery_status';
 import { DeliveryType } from './delivery_type';
 
@@ -288,6 +288,6 @@ export interface Tracking {
     /**
      * Array of Hash describes the checkpoint information.
      */
-    checkpoints?: [CheckPoint];
+    checkpoints?: [Checkpoint];
   };
 }

--- a/test/test_last_checkpoint.js
+++ b/test/test_last_checkpoint.js
@@ -6,13 +6,13 @@ var chai = require("chai");
 var expect = chai.expect;
 var aftership = new Aftership("SOME_API_KEY");
 
-describe("LastCheckPoint", function () {
-  describe("#getLastCheckPoint(), validate params", function () {
+describe("LastCheckpoint", function () {
+  describe("#getLastCheckpoint(), validate params", function () {
     it("should throw exception when not specify tracking id and tracking number", async function () {
       let expected_error =
         "HandlerError: You must specify the tracking number or tracking id";
       try {
-        await aftership.last_checkpoint.getLastCheckPoint();
+        await aftership.last_checkpoint.getLastCheckpoint();
       } catch (e) {
         expect(e.message).to.equal(expected_error);
       }
@@ -27,7 +27,7 @@ describe("LastCheckPoint", function () {
         tracking_number: "1234567890",
       };
       try {
-        await aftership.last_checkpoint.getLastCheckPoint(param);
+        await aftership.last_checkpoint.getLastCheckpoint(param);
       } catch (e) {
         expect(e.message).to.equal(expected_error);
       }
@@ -40,7 +40,7 @@ describe("LastCheckPoint", function () {
         slug: "ups",
       };
       try {
-        await aftership.last_checkpoint.getLastCheckPoint(param);
+        await aftership.last_checkpoint.getLastCheckpoint(param);
       } catch (e) {
         expect(e.message).to.equal(expected_error);
       }
@@ -53,14 +53,14 @@ describe("LastCheckPoint", function () {
         tracking_number: "1234567890",
       };
       try {
-        await aftership.last_checkpoint.getLastCheckPoint(param);
+        await aftership.last_checkpoint.getLastCheckpoint(param);
       } catch (e) {
         expect(e.message).to.equal(expected_error);
       }
     });
   });
 
-  describe("#getLastCheckPoint({slug, tracking_number})", function () {
+  describe("#getLastCheckpoint({slug, tracking_number})", function () {
     it("should get last checkpoint when success", function (done) {
       const param = {
         slug: "ups",
@@ -111,7 +111,7 @@ describe("LastCheckPoint", function () {
         );
 
       aftership.last_checkpoint
-        .getLastCheckPoint(param)
+        .getLastCheckpoint(param)
         .then((result) => {
           if (
             result &&
@@ -155,7 +155,7 @@ describe("LastCheckPoint", function () {
         );
 
       aftership.last_checkpoint
-        .getLastCheckPoint(param)
+        .getLastCheckpoint(param)
         .then(_ => {
           done("not catch the exception");
         })
@@ -169,7 +169,7 @@ describe("LastCheckPoint", function () {
     });
   });
 
-  describe("#getLastCheckPoint({tracking_id})", function () {
+  describe("#getLastCheckpoint({tracking_id})", function () {
     it("should get last checkpoint when success", function (done) {
       const param = {
         tracking_id: "5b74f4958776db0e00b6f5ed",
@@ -217,7 +217,7 @@ describe("LastCheckPoint", function () {
       );
 
       aftership.last_checkpoint
-        .getLastCheckPoint(param)
+        .getLastCheckpoint(param)
         .then((result) => {
           if (
             result &&
@@ -258,7 +258,7 @@ describe("LastCheckPoint", function () {
       );
 
       aftership.last_checkpoint
-        .getLastCheckPoint(param)
+        .getLastCheckpoint(param)
         .then(_ => {
           done("not catch the exception");
         })


### PR DESCRIPTION
- Rename `CheckPoint` to `Checkpoint`
- Remove `process.env`  to make sure the module will support client side.