### PR TITLE
Only set User-Agent header in Node

### DIFF
--- a/src/lib/api_request.ts
+++ b/src/lib/api_request.ts
@@ -58,13 +58,17 @@ export class ApiRequestImplementation implements ApiRequest {
     });
 
     const request_id = uuidv4();
-    const headers = {
+    const headers: any = {
       'aftership-api-key': this.app.apiKey,
       'Content-Type': 'application/json',
       'request-id': request_id,
-      'User-Agent': `${this.app.user_agent_prefix}/${VERSION}`,
       'aftership-agent': `nodejs-sdk-${VERSION}`,
     };
+
+    // Only set User-Agent header in Node
+    if (typeof window === 'undefined') {
+      headers['User-Agent'] = `${this.app.user_agent_prefix}/${VERSION}`;
+    }
 
     const request = axios.request({
       url,


### PR DESCRIPTION
To prevent the error `Refused to set unsafe header "User-Agent"` in browser, we should only set `User-Agent` header in server side (Node.js). 