### PR TITLE
Update request data to undefined instead of null

### DIFF
--- a/src/lib/api_request.ts
+++ b/src/lib/api_request.ts
@@ -75,7 +75,7 @@ export class ApiRequestImplementation implements ApiRequest {
       method,
       headers,
       baseURL: this.app.endpoint,
-      data: data !== undefined ? { ...data } : null,
+      data: data !== undefined ? { ...data } : undefined,
       timeout: TIMEOUT,
     });
 


### PR DESCRIPTION
When we define data = null in axios (as it was in the code), axios sends a empty body. 
For any reason, Aftership API is trying to handle not empty HTTP body and is returning HTTP code 400  - Bad Request and the body comes with an HTML ("Your client has issued a malformed or illegal request").

I replace null with undefined, so axios doesn't send any HTTP body, and the Aftership API works.

I was facing this issue for all /couriers GET endpoints.